### PR TITLE
Add v-select append-to-body prop to prevent z-index issues

### DIFF
--- a/resources/js/LinkItFieldtype.vue
+++ b/resources/js/LinkItFieldtype.vue
@@ -3,6 +3,7 @@
     <div class="flex flex-wrap items-center">
       <v-select
         class="w-1/5 mr-2"
+        append-to-body
         :options="types"
         :reduce="selection => selection.value"
         v-model="internal.type"
@@ -13,6 +14,7 @@
       <v-select
         v-if="internal.type === 'term'"
         class="w-1/5"
+        append-to-body
         :options="taxonomies"
         :reduce="selection => selection.value"
         v-model="internal.taxonomy"
@@ -52,6 +54,7 @@
       <v-select
         v-if="internal.type === 'asset'"
         class="w-1/5"
+        append-to-body
         :options="containers"
         :reduce="selection => selection.value"
         v-model="internal.container"

--- a/resources/js/LinkItFieldtype.vue
+++ b/resources/js/LinkItFieldtype.vue
@@ -4,6 +4,7 @@
       <v-select
         class="w-1/5 mr-2"
         append-to-body
+        :calculate-position="positionOptions"
         :options="types"
         :reduce="selection => selection.value"
         v-model="internal.type"
@@ -15,6 +16,7 @@
         v-if="internal.type === 'term'"
         class="w-1/5"
         append-to-body
+        :calculate-position="positionOptions"
         :options="taxonomies"
         :reduce="selection => selection.value"
         v-model="internal.taxonomy"
@@ -55,6 +57,7 @@
         v-if="internal.type === 'asset'"
         class="w-1/5"
         append-to-body
+        :calculate-position="positionOptions"
         :options="containers"
         :reduce="selection => selection.value"
         v-model="internal.container"
@@ -202,8 +205,10 @@
   </div>
 </template>
 <script>
+import PositionsSelectOptions from '../../../../../vendor/statamic/cms/resources/js/mixins/PositionsSelectOptions.js'
+
 export default {
-  mixins: [Fieldtype],
+  mixins: [Fieldtype, PositionsSelectOptions],
 
   data: function() {
     return {


### PR DESCRIPTION
Since upgrading to Statamic 4, the package dropdowns suffer from z-index issues with other Statamic components. Statamic 4 also uses this property see [here](https://github.com/statamic/cms/blob/4.x/resources/js/components/inputs/relationship/SelectField.vue).

One thing I didn't add was the `PositionsSelectOptions` mixin that Statamic uses in conjunction with the `:calculate-position` on vue-select.

I have yet to discover any issues not using this mixin. Primary reason for not including is I didn't want to tightly couple a mixin from Statamic with this package. Happy to add if you would prefer @riasvdv?