### PR TITLE
fix: build path issue causing assets not to copy over

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -20,7 +20,7 @@ class ServiceProvider extends AddonServiceProvider
             'resources/js/cp.js',
             'resources/css/link-it.css',
         ],
-        'publicDirectory' => 'dist',
+        'publicDirectory' => 'resources/dist',
         'hotFile' => __DIR__.'/../dist/hot',
     ];
 


### PR DESCRIPTION
This resolves an issue with the Statamic 6 update that is preventing asset files from copying over successfully resulting in errors when of missing files within the CP. 

Updating the path to the new dist files resolves this issue.