### PR TITLE
Fix TypeError when selecting entries, terms, or assets

### DIFF
--- a/resources/js/LinkItFieldtype.vue
+++ b/resources/js/LinkItFieldtype.vue
@@ -238,17 +238,17 @@ export default {
     },
     "internal.container": function(newValue, oldValue) {
       if (newValue !== oldValue && oldValue !== null) {
-        this.internal.asset = null;
+        this.internal.asset = [];
       }
     },
     "internal.collection": function(newValue, oldValue) {
       if (newValue !== oldValue && oldValue !== null) {
-        this.internal.entry = null;
+        this.internal.entry = [];
       }
     },
     "internal.taxonomy": function(newValue, oldValue) {
       if (newValue !== oldValue && oldValue !== null) {
-        this.internal.term = null;
+        this.internal.term = [];
       }
     },
     "internal.type": function(newValue, oldValue) {
@@ -272,6 +272,14 @@ export default {
         this.internal.title = "";
         this.internal.append = "";
       }
+
+      // Ensure relationship fields are arrays, not null. When the type is
+      // selected for the first time (oldValue is null), the reset block above
+      // is skipped, leaving these as their initial null value. Statamic's
+      // Selector component expects an array for initialSelections.
+      if (this.internal.entry === null) this.internal.entry = [];
+      if (this.internal.term === null) this.internal.term = [];
+      if (this.internal.asset === null) this.internal.asset = [];
 
       if (newValue === "entry" && this.meta.collections.length === 1) {
         this.internal.collection = this.meta.collections[0].value;

--- a/src/LinkItFieldtype.php
+++ b/src/LinkItFieldtype.php
@@ -142,7 +142,7 @@ class LinkItFieldtype extends Fieldtype
                         'config' => $field->config(),
                         'meta' => $field->preload(),
                     ];
-                })->all(),
+                })->values()->all(),
             'containers' => AssetContainer::all()
                 ->whereIn('handle', $fieldConfig['containers'] ?? [])
                 ->map(function (\Statamic\Assets\AssetContainer $container) use ($value) {
@@ -159,7 +159,7 @@ class LinkItFieldtype extends Fieldtype
                         'config' => $field->config(),
                         'meta' => $field->preload(),
                     ];
-                })->all(),
+                })->values()->all(),
             'taxonomies' => Taxonomy::all()
                 ->whereIn('handle', $fieldConfig['taxonomies'] ?? [])
                 ->map(function (\Statamic\Taxonomies\Taxonomy $taxonomy) use ($value) {
@@ -176,7 +176,7 @@ class LinkItFieldtype extends Fieldtype
                         'config' => $field->config(),
                         'meta' => $field->preload(),
                     ];
-                })->all(),
+                })->values()->all(),
         ];
     }
 


### PR DESCRIPTION
## Problem

Two related bugs when using the `link_it` fieldtype (e.g. inside a grid):

### 1. TypeError on entry/term/asset selection

Selecting an entry in the relationship picker throws:

- **List view**: `TypeError: Cannot read properties of null (reading 'indexOf')` in `toggleSelection`
- **Tree view**: `TypeError: Cannot read properties of null (reading 'includes')` in `isSelected`

**Cause**: `internal.entry`, `internal.term`, and `internal.asset` are initialized as `null` in `data()`. When the type is selected for the first time on a new row, the `internal.type` watcher's reset block is skipped because `oldValue` is `null`:

```js
if (newValue !== oldValue && oldValue !== null) {
    // this block sets entry/term/asset to [] but is skipped
}
```

The `null` value propagates through `relationship-fieldtype` → `RelationshipInput` → `Selector` as `initialSelections`, where `clone(null)` returns `null`, and `null.indexOf()` / `null.includes()` crashes.

### 2. Collections/containers/taxonomies dropdown hidden

After selecting "Entry" type, the collections dropdown doesn't appear.

**Cause**: `preload()` returns collections with non-sequential array keys because `whereIn()` preserves the original indices from `Collection::all()`. For example, keys `[2, 4]` cause `json_encode` to produce a JSON **object** (`{"2": ..., "4": ...}`) instead of an **array** (`[..., ...]`). In JavaScript, `meta.collections.length` on an object is `undefined`, so `v-show="meta.collections.length >= 1"` evaluates to `false`.

## Fix

1. Add null-to-array coercion after the conditional reset block in the `internal.type` watcher
2. Add `->values()` before `->all()` in `preload()` to reset array keys

## Note

The dist file (`resources/dist/build/assets/cp--am3jAUE.js`) needs to be rebuilt to include the Vue source fix.